### PR TITLE
Update dependencies for Statamic 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1",
         "fakerphp/faker": "^1.23.0",
         "laravel/prompts": "^0.1.17",
-        "statamic/cms": "^4.0",
+        "statamic/cms": "^5.0",
         "stillat/primitives": "^1.4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Updates the composer version for the new v5 version of Statamic.

Tested this in Statamic and the factories worked without issue.